### PR TITLE
修复新增区域的上传问题

### DIFF
--- a/sdk/qiniuUploader.js
+++ b/sdk/qiniuUploader.js
@@ -1,7 +1,7 @@
 (function () {
     // 请参考demo的index.js中的initQiniu()方法，若在使用处对options进行了赋值，则此处config不需要赋默认值。init(options) 即updateConfigWithOptions(options)，会对config进行赋值
     var config = {
-        // bucket 所在区域。ECN, SCN, NCN, NA, ASG，分别对应七牛云的：华东，华南，华北，北美，新加坡 5 个区域
+        // bucket 所在区域。ECN, ECN-2 SCN, NCN, NA, ASG，分别对应七牛云的：华东-浙江，华东-浙江2，华南-广东，华北-河北，北美-洛杉矶，亚太-新加坡（原东南亚） ,6 个区域
         qiniuRegion: '',
         // 七牛云bucket 外链前缀，外链在下载资源时用到
         qiniuBucketURLPrefix: '',
@@ -164,16 +164,17 @@
         })
     }
 
-    // 选择七牛云文件上传接口，文件向匹配的接口中传输。ECN, SCN, NCN, NA, ASG，分别对应七牛云的：华东，华南，华北，北美，新加坡 5 个区域
+    // 选择七牛云文件上传接口，文件向匹配的接口中传输。ECN, ECN-2, SCN, NCN, NA, ASG，分别对应七牛云的：华东，华南，华北，北美，新加坡 5 个区域
     function uploadURLFromRegionCode(code) {
         var uploadURL = null;
         switch (code) {
             case 'ECN': uploadURL = 'https://up.qiniup.com'; break;
+            case 'ECN-2': uploadURL = 'https://up-cn-east-2.qiniup.com'; break;
             case 'NCN': uploadURL = 'https://up-z1.qiniup.com'; break;
             case 'SCN': uploadURL = 'https://up-z2.qiniup.com'; break;
             case 'NA': uploadURL = 'https://up-na0.qiniup.com'; break;
             case 'ASG': uploadURL = 'https://up-as0.qiniup.com'; break;
-            default: console.error('please make the region is with one of [ECN, SCN, NCN, NA, ASG]');
+            default: console.error('please make the region is with one of [ECN, ECN-2, SCN, NCN, NA, ASG]');
         }
         return uploadURL;
     }

--- a/sdk/qiniuUploader.ts
+++ b/sdk/qiniuUploader.ts
@@ -1,7 +1,7 @@
 type TokenFunction = () => string;
 type AnyFunction = (...args: any[]) => any;
 
-export type RegionCode = 'ECN' | 'NCN' | 'SCN' | 'NA' | 'ASG' | '';
+export type RegionCode = 'ECN' | 'ECN-2' | 'NCN' | 'SCN' | 'NA' | 'ASG' | '';
 
 
 interface QiniuConfig {
@@ -43,7 +43,7 @@ export interface QiniuUploadOptions {
 
 
 const config: QiniuConfig = {
-    // bucket 所在区域。ECN, SCN, NCN, NA, ASG，分别对应七牛云的：华东，华南，华北，北美，新加坡 5 个区域
+    // bucket 所在区域。ECN, ECN-2 SCN, NCN, NA, ASG，分别对应七牛云的：华东-浙江，华东-浙江2，华南-广东，华北-河北，北美-洛杉矶，亚太-新加坡（原东南亚） ,6 个区域
     qiniuRegion: '',
     // 七牛云bucket 外链前缀，外链在下载资源时用到
     qiniuBucketURLPrefix: '',
@@ -225,6 +225,9 @@ function uploadURLFromRegionCode(code: RegionCode): string | null {
         case 'ECN':
             uploadURL = 'https://up.qiniup.com';
             break;
+        case 'ECN-2':
+            uploadURL = 'https://up-cn-east-2.qiniup.com';
+            break;
         case 'NCN':
             uploadURL = 'https://up-z1.qiniup.com';
             break;
@@ -239,7 +242,7 @@ function uploadURLFromRegionCode(code: RegionCode): string | null {
             break;
         default:
             console.error(
-                'please make the region is with one of [ECN, SCN, NCN, NA, ASG]'
+                'please make the region is with one of [ECN, ECN-2, SCN, NCN, NA, ASG]'
             );
     }
     return uploadURL;


### PR DESCRIPTION
七牛云新增区域： 华东-浙江2
对应的上传地址为：http(s)://up-cn-east-2.qiniup.com
具体详情如下图，[原文链接](https://developer.qiniu.com/kodo/1671/region-endpoint-fq)：
![image](https://github.com/gpake/qiniu-wxapp-sdk/assets/70583417/26fb40fb-9b14-449f-987a-5cd1b1d40342)
